### PR TITLE
Updated "Student Team" and "Contact Us" sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1071,13 +1071,13 @@
 
           <div class="row">
             <div class="col-sm ">
-              <h3>Annappa B</h3>
+              <h3>Prof. Annappa B</h3>
               <h5>Chairman IEEE Mangalore Sub Section</h5>
               <h5>Email: annappa@ieee.org</h5>
              </div>
              <br>
             <div class="col-sm">
-              <h3>M. S. Bhat</h3>
+              <h3>Prof. M. S. Bhat</h3>
               <h5>Branch Counsellor NITK IEEE</h5>
               <h5>Email: msbhat@ieee.org</h5>
              </div>
@@ -1086,20 +1086,40 @@
             <br>
             <div class="row">
                 <div class="col-sm">
+                  <h3>Mrs. Saumya Hegde</h3>
+                  <h5>WiE Chair, IEEE Mangalore Subsection</h5>
+                  <h5>Email: saumya@nitk.ac.in</h5>
+                 </div>
+                 <br>
+                 <div class="col-sm">
+                  <h3>Dr. R Kalpana</h3>
+                  <h5>WiE Co-Chair, IEEE Mangalore Subsection</h5>
+                  <h5>Email: dr.kalpana.nitk@gmail.com</h5>
+                </div>
+            </div>
+            <br>
+            <div class="row">
+                <div class="col-sm">
+                  <h3>Dr. Rekha S</h3>
+                  <h5>WiE Chair, NITK IEEE Affinity Group</h5>
+                  <h5>Email: rsbhat_99@yahoo.com</h5>
+                 </div>
+                 <br>
+                 <div class="col-sm">
                   <h3>Sailakshmi P V</h3>
                   <h5>WiT Coordinator</h5>
                   <h5>Email: sailakshmi.pv.in@ieee.org</h5>
-                 </div>
-                 <br>
-                <div class="col-sm">
-                  <h3>Sagar Bharadwaj</h3>
-                  <h5>WiT Coordinator</h5>
-                  <h5>Email: sagarbharadwaj50@gmail.com</h5>
-                 </div>
                 </div>
+            </div>
                 <br>
 
                 <div class="row">
+                  <div class="col-sm">
+                    <h3>Sagar Bharadwaj</h3>
+                    <h5>WiT Coordinator</h5>
+                    <h5>Email: sagarbharadwaj50@gmail.com</h5>
+                  </div>
+                  <br>
                     <div class="col-sm">
                       <h3>Samarth Bonthala</h3>
                       <h5>Tracker Committee Lead</h5>

--- a/index.html
+++ b/index.html
@@ -840,18 +840,18 @@
               </div>
            </div>
 
-
+           <br>
             <div class="row">
                 <div class="col-sm">
                   <h3>Sailakshmi P V</h3>
                   <h5>WiT Coordinator</h5>
-                
+                  <h5>Kerala Section Young Professional</h5>
                  </div>
                  <br>
             <div class="col-sm">
               <h3>Sagar Bharadwaj</h3>
               <h5>WiT Coordinator</h5>
-             
+              <h5>NITK IEEE Volunteer, Bangalore Section</h5>
              </div>
             </div>
             <br>
@@ -860,12 +860,13 @@
                 <div class="col-sm">
                   <h3>Samarth Bonthala</h3>
                   <h5>Tracker Committee Lead</h5>
-                 
+                  <h5>NITK IEEE Volunteer, Bangalore Section</h5>
                  </div>
             <br>
             <div class="col-sm">
               <h3>Rosa George</h3>
               <h5>Joint Coordinator</h5>
+              <h5>NITK IEEE Volunteer, Bangalore Section</h5>
              </div>
             </div>
             <br>
@@ -873,12 +874,13 @@
               <div class="col-sm">
                 <h3>Neeraj V Ipe</h3>
                 <h5>Website Lead</h5>
-             
+                <h5>CS India SAC Volunteer, Kerala Section</h5>
                </div>
             <br>
             <div class="col-sm">
               <h3>Anumeha Agrawal</h3>
               <h5>Website Lead</h5>
+              <h5>NITK IEEE Volunteer, Bangalore Section</h5>
              </div>
             </div>
             <br>
@@ -886,12 +888,13 @@
               <div class="col-sm">
                 <h3>Afnan Nazer</h3>
                 <h5>Design Team Lead</h5>
-             
+                <h5>CS India SAC Volunteer, Kerala Section</h5>
                </div>
             <br>
             <div class="col-sm">
               <h3>Kaushik Kalmady</h3>
               <h5>Logistics Team Lead</h5>
+              <h5>NITK IEEE Volunteer, Bangalore Section</h5>
              </div>
             </div>
             <br>
@@ -899,12 +902,13 @@
               <div class="col-sm">
                 <h3> Saikrishna V</h3>
                 <h5>Publicity Team Lead</h5>
-             
+                <h5>CS India SAC Volunteer, Kerala Section</h5>
                </div>
             <br>
             <div class="col-sm">
               <h3>Abdul Halik </h3>
               <h5>Registration Team Lead</h5>
+              <h5>CS India SAC Volunteer, Madras Section</h5>
              </div>
             </div>
             <br>
@@ -912,12 +916,13 @@
               <div class="col-sm">
                 <h3> Jeshvanth T K</h3>
                 <h5>Finance Team Lead</h5>
-             
+                <h5>NITK IEEE Volunteer, Bangalore Section</h5>
                </div>
             <br>
             <div class="col-sm">
               <h3>Mohd Sharif </h3>
               <h5>Registration Team Lead</h5>
+              <h5>Hyderabad Section Young Professional</h5>
              </div>
             </div>
             <br>
@@ -925,12 +930,13 @@
               <div class="col-sm">
                 <h3> Adwaith Gautam</h3>
                 <h5>Computing Track Lead</h5>
-             
+                <h5>NITK IEEE Volunteer, Bangalore Section</h5>
                </div>
             <br>
             <div class="col-sm">
               <h3>Mohita Chowdhury</h3>
               <h5>Electronics and Automation Track Lead</h5>
+              <h5>NITK IEEE Volunteer, Bangalore Section</h5>
              </div>
             </div>
             <br>
@@ -938,10 +944,23 @@
               <div class="col-sm">
                 <h3> Adil Ashique</h3>
                 <h5>Entrepreneurship Track Lead</h5>
-             
+                <h5>NITK IEEE Volunteer, Bangalore Section</h5>
                </div>
             <br>
+              <div class="col-sm">
+                <h3>Karthik K</h3>
+                <h5>Sponsorship Team Lead</h5>
+                <h5>CS India SAC Volunteer, Kerala Section</h5>
+              </div>
             </div>
+            <br>
+            <div class="row">
+              <div class="col-sm">
+                <h3>Daphne Jenson</h3>
+                <h5>Documentation Lead</h5>
+                <h5>IEEE CS India SAC Volunteer, Madras Section</h5>
+              </div>
+          </div>
             <br>
 
 
@@ -1068,7 +1087,7 @@
               <h1>CONTACT US</h1>
               </div>
            </div>
-
+          <br>
           <div class="row">
             <div class="col-sm ">
               <h3>Prof. Annappa B</h3>


### PR DESCRIPTION
Closes #52 
Closes #53 

### Changes made
* Added "Prof" before the two professor's names.
* Added the three professor's contacts.
* Added from where each person is in the "Student Team" section.
* Added two more students in that section.

### Screenshots
![screenshot_2018-12-03 wit summit december 21 - 24 2018](https://user-images.githubusercontent.com/23053790/49374428-4ba9bb00-f727-11e8-9a7e-b567f75faeaa.png)
![screenshot_2018-12-03 wit summit december 21 - 24 2018 1](https://user-images.githubusercontent.com/23053790/49374430-4f3d4200-f727-11e8-8986-ff3c1ec63453.png)
![screenshot_2018-12-03 wit summit december 21 - 24 2018 2](https://user-images.githubusercontent.com/23053790/49374433-53695f80-f727-11e8-9e1a-de8a5ceafa72.png)


### Note
There are two replicas of "Student Team" section in the code. I've made changes only to the one which is actually visible. I believe the other wasn't supposed to be updated (and isn't supposed to be there at all). 