### PR TITLE
Main Nav Font Size changed

### DIFF
--- a/css/main.min.css
+++ b/css/main.min.css
@@ -127,7 +127,7 @@ section{
 }
 
 #mainNav .navbar-nav>li.nav-item>a.nav-link,#mainNav .navbar-nav>li.nav-item>a.nav-link:focus{
-	font-size:0.9rem;
+	font-size:0.83rem;
 	font-weight:500;
 	color:#ffffff
 }


### PR DESCRIPTION
The font size of the main navigation bar reduced so that the navigation bar fits in the screen of a computer. Hence this solves #87 
Screenshot:
![image](https://user-images.githubusercontent.com/32371951/50273645-3213ad80-0461-11e9-8b9f-972b127ee8b2.png)
